### PR TITLE
Reduce cpu load by updating system info less frequently

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let mut city = MetropolisCity::new(distro, weather);
     
     let tick_rate = Duration::from_millis(50); 
+    let sysinfo_tick_rate = Duration::from_millis(1000);
     let mut last_tick = Instant::now();
+    let mut last_sysinfo_tick = Instant::now();
     let mut proc_names: Vec<String> = Vec::new();
     let mut proc_tick_count = 0;
     let mut last_disk_bytes = 0u64;
@@ -73,7 +75,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
         }
 
         if last_tick.elapsed() >= tick_rate {
-            sys.refresh_all();
+            if last_sysinfo_tick.elapsed() >= sysinfo_tick_rate {
+                sys.refresh_all();
+                last_sysinfo_tick = Instant::now();
+            }
+
             let cpu = sys.global_cpu_info().cpu_usage();
             let ram = (sys.used_memory() as f32 / sys.total_memory() as f32) * 100.0;
             


### PR DESCRIPTION
Currently on my Ryzen 5600 this program uses about 10% CPU which seems a bit excessive for something like this. On a lower end device, the performance impact is even more severe. This program makes for a nice and quirky animation to eg. run on a second monitor or run as desktop background with something like kitten panel in which case the performance impact is quite annoying

The main culprit is running `sys.refresh_all()`, which is quite an expensive operation, every 50ms. More pragmatic system monitors like htop update info only once per two seconds (more or less). I suggest updating the animations every 50ms but only refreshing system info once per second, which makes the performance impact negligible