### PR TITLE
Update GitHub Actions to Node.js 24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout Source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -49,7 +49,7 @@ jobs:
           cp target/${{ matrix.platform.target }}/release/${{ matrix.platform.bin }} dist/${{ matrix.platform.bin }}
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: metropolis-${{ matrix.platform.target }}
           path: dist/${{ matrix.platform.bin }}
@@ -60,10 +60,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download All Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: ./release-assets
           merge-multiple: true


### PR DESCRIPTION
All actions in `release.yml` are running on Node.js 20 which will be force-migrated to Node.js 24 on June 2nd, 2026 and removed entirely on September 16th, 2026. It's best to get ahead of this early so kinks can be sorted out. The changes are:

- actions/checkout@v4 to @v6
- actions/upload-artifact@v4 to @v6
- actions/download-artifact@v4 to @v7

Closes #15 